### PR TITLE
add streamx as explicit dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "homepage": "https://github.com/andrewosh/hyperblob#readme",
   "dependencies": {
     "abort-controller": "^3.0.0",
-    "mutexify": "^1.3.1"
+    "mutexify": "^1.3.1",
+    "streamx": "^2.12.4"
   },
   "devDependencies": {
     "hypercore": "next",


### PR DESCRIPTION
forces use of streamx version that ensures Pipeline.pipeAfter is always a function (or null)