### PR TITLE
Custom core and snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,19 @@ Options can include:
   blockSize: 64KB, // The block size that will be used when storing large blobs.
   start: 0, // Relative offset to start within the blob
   end: blob.length - 1, // End offset within the blob (inclusive)
-  length: blob.length // Number of bytes to read.
+  length: blob.length, // Number of bytes to read.
+  core // A custom core to write (overrides the default core)
 }
+```
+
+#### `const content = await blobs.get(id, opts)`
+Return a complete blob as a `Buffer`.
+
+`id` is the value returned by `put`
+
+Options can include:
+```js
+  core // A custom core to read from (overrides the default core)
 ```
 
 #### `const stream = blobs.createReadStream(id, opts)`

--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ Return a complete blob as a `Buffer`.
 
 Options can include:
 ```js
+{
   core // A custom core to read from (overrides the default core)
+}
 ```
 
 #### `const stream = blobs.createReadStream(id, opts)`

--- a/index.js
+++ b/index.js
@@ -46,10 +46,12 @@ module.exports = class Hyperblobs {
   }
 
   createReadStream (id, opts) {
-    return new BlobReadStream(this._core, id, opts)
+    const core = (opts && opts.core) ? opts.core : this._core
+    return new BlobReadStream(core, id, opts)
   }
 
   createWriteStream (opts) {
-    return new BlobWriteStream(this._core, this._lock, opts)
+    const core = (opts && opts.core) ? opts.core : this._core
+    return new BlobWriteStream(core, this._lock, opts)
   }
 }

--- a/lib/streams.js
+++ b/lib/streams.js
@@ -1,4 +1,3 @@
-const AbortController = require('abort-controller')
 const { Readable, Writable } = require('streamx')
 
 class SparsePrefetcher {
@@ -89,7 +88,6 @@ class BlobReadStream extends Readable {
     this.id = id
     this.core = core.snapshot()
 
-    this._controller = new AbortController()
     this._prefetch = opts.prefetch
     this._lastPrefetch = null
     if (!this._prefetch) {
@@ -141,7 +139,7 @@ class BlobReadStream extends Readable {
       this._lastPrefetch = this.core.download(prefetch)
     }
 
-    this.core.get(this._index, { signal: this._controller.signal }).then(block => {
+    this.core.get(this._index).then(block => {
       const remainder = this._end - this._pos
       if (this._relativeOffset || (remainder < block.length)) {
         block = block.slice(this._relativeOffset, this._relativeOffset + remainder)

--- a/lib/streams.js
+++ b/lib/streams.js
@@ -123,6 +123,10 @@ class BlobReadStream extends Readable {
     }, err => cb(err))
   }
 
+  _predestroy () {
+    this.core.close().then(noop, noop)
+  }
+
   _destroy (cb) {
     this.core.close().then(cb, cb)
   }
@@ -160,3 +164,5 @@ module.exports = {
   BlobReadStream,
   BlobWriteStream
 }
+
+function noop () {}

--- a/lib/streams.js
+++ b/lib/streams.js
@@ -87,7 +87,7 @@ class BlobReadStream extends Readable {
   constructor (core, id, opts = {}) {
     super(opts)
     this.id = id
-    this.core = core
+    this.core = core.snapshot()
 
     this._controller = new AbortController()
     this._prefetch = opts.prefetch
@@ -123,6 +123,10 @@ class BlobReadStream extends Readable {
       this._relativeOffset = result[1]
       return cb(null)
     }, err => cb(err))
+  }
+
+  _destroy (cb) {
+    this.core.close().then(cb, cb)
   }
 
   _read (cb) {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   },
   "homepage": "https://github.com/andrewosh/hyperblob#readme",
   "dependencies": {
-    "abort-controller": "^3.0.0",
     "mutexify": "^1.3.1",
     "streamx": "^2.12.4"
   },

--- a/test/all.js
+++ b/test/all.js
@@ -103,3 +103,19 @@ test('basic seek', async t => {
 
   t.end()
 })
+
+test('can pass in a custom core', async t => {
+  const core1 = new Hypercore(ram)
+  const core2 = new Hypercore(ram)
+  const blobs = new Hyperblobs(core1)
+  await core1.ready()
+
+  const buf = Buffer.alloc(5 * blobs.blockSize).fill('abcdefg')
+  const id = await blobs.put(buf, { core: core2 })
+  const result = await blobs.get(id, { core: core2 })
+  t.true(result.equals(buf))
+
+  t.same(core1.length, 0)
+
+  t.end()
+})


### PR DESCRIPTION
Adds the ability to pass in a custom core (with the `core` option) to all methods. Also makes the read stream use a Hypercore snapshot.